### PR TITLE
Call the delegate also when setting the selected date programmatically

### DIFF
--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -358,6 +358,7 @@
     _selectedDate = selectedDate;
     [self setNeedsLayout];
     self.monthShowing = selectedDate;
+    [self.delegate calendar:self didSelectDate:self.selectedDate];
 }
 
 - (void)setShouldFillCalendar:(BOOL)shouldFillCalendar {
@@ -429,7 +430,6 @@
         return;
     } else {
         self.selectedDate = date;
-        [self.delegate calendar:self didSelectDate:self.selectedDate];
     }
 }
 


### PR DESCRIPTION
Very simple patch. This causes the delegate method to be called also when using the setSelectedDate method, not just when the user selects a day through the interface.

Note: this patch scratched an itch that I had. I understand that it changes the behavior of the delegate and some use cases might not like this. It's completely fine to not merge this patch if it's too risky to include it or for any other reason for that matter. I just have to scratch my itch somehow differently then.
