### PR TITLE
-calendar:didChangeMonth for delegate added

### DIFF
--- a/Source/CKCalendarView.h
+++ b/Source/CKCalendarView.h
@@ -80,4 +80,7 @@ typedef int startDay;
 
 - (void)calendar:(CKCalendarView *)calendar didSelectDate:(NSDate *)date;
 
+@optional
+- (void)calendar:(CKCalendarView *)calendar didChangeMonth:(NSDate *)date;
+
 @end

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -436,12 +436,18 @@
     NSDateComponents* comps = [[NSDateComponents alloc] init];
     [comps setMonth:1];
     self.monthShowing = [self.calendar dateByAddingComponents:comps toDate:self.monthShowing options:0];
+    if ( [self.delegate respondsToSelector:@selector(calendar:didChangeMonth:)] ) {
+        [self.delegate calendar:self didChangeMonth:self.monthShowing];
+    }
 }
 
 - (void)moveCalendarToPreviousMonth {
     NSDateComponents* comps = [[NSDateComponents alloc] init];
     [comps setMonth:-1];
     self.monthShowing = [self.calendar dateByAddingComponents:comps toDate:self.monthShowing options:0];
+    if ( [self.delegate respondsToSelector:@selector(calendar:didChangeMonth:)] ) {
+        [self.delegate calendar:self didChangeMonth:self.monthShowing];
+    }
 }
 
 - (void)dateButtonPressed:(id)sender {


### PR DESCRIPTION
I want to know when the calendar is going to resize itself to be taller (possibly) so that any views I have underneath it can be redrawn. 

This delegate method allows me to do that, example usage:

``` c
- (void) calendar:(CKCalendarView*)calendar didChangeMonth:(NSDate *)date {
  [self setNeedsLayout];
}
```
