### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ CKCalendar is a sleek, easily customizable calendar control for iOS. Simply add 
 
 ![CKCalendar screenshot](http://cloud.github.com/downloads/jaykz52/CKCalendar/CKCalendar.png)
 
+<!-- MacBuildServer Install Button -->
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=Examples%2FCalendar.xcodeproj&amp;target=Calendar&amp;repo_url=git%3A%2F%2Fgithub.com%2Fjaykz52%2FCKCalendar.git&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+<!-- MacBuildServer Install Button -->
+
 The default calendar design is courtesy of [John Anderson](http://twitter.com/jrileyd). Thanks John!
 
 ## Interacting with CKCalendar


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
