### PR TITLE
Fix issue #40

### DIFF
--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -77,8 +77,12 @@
 
 - (void)setDate:(NSDate *)date {
     _date = date;
-    NSDateComponents *comps = [self.calendar components:NSDayCalendarUnit|NSMonthCalendarUnit fromDate:date];
-    [self setTitle:[NSString stringWithFormat:@"%d", comps.day] forState:UIControlStateNormal];
+    if (date) {
+        NSDateComponents *comps = [self.calendar components:NSDayCalendarUnit|NSMonthCalendarUnit fromDate:date];
+        [self setTitle:[NSString stringWithFormat:@"%d", comps.day] forState:UIControlStateNormal];
+    } else {
+        [self setTitle:@"" forState:UIControlStateNormal];
+    }
 }
 
 @end


### PR DESCRIPTION
Removes setting of DateButton's date to nil. It caused components:fromDate: on NSCalendar to be sent with fromDate equal to nil and showed an error in the target output.
