### PR TITLE
Removed first day of week references; will take reference from locale

### DIFF
--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -17,7 +17,7 @@
 - (id)init {
     self = [super init];
     if (self) {
-        CKCalendarView *calendar = [[CKCalendarView alloc] initWithStartDay:startMonday];
+        CKCalendarView *calendar = [[CKCalendarView alloc] init];
         self.calendar = calendar;
         calendar.delegate = self;
 

--- a/Source/CKCalendarView.h
+++ b/Source/CKCalendarView.h
@@ -26,17 +26,10 @@
 
 @end
 
-typedef enum {
-    startSunday = 1,
-    startMonday = 2,
-} CKCalendarStartDay;
-
 @interface CKCalendarView : UIView
 
-- (id)initWithStartDay:(CKCalendarStartDay)firstDay;
-- (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame;
+- (id)initWithFrame:(CGRect)frame;
 
-@property (nonatomic) CKCalendarStartDay calendarStartDay;
 @property (nonatomic, strong) NSLocale *locale;
 
 @property (nonatomic, readonly) NSArray *datesShowing;

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -79,7 +79,7 @@
     _date = date;
     if (date) {
         NSDateComponents *comps = [self.calendar components:NSDayCalendarUnit|NSMonthCalendarUnit fromDate:date];
-        [self setTitle:[NSString stringWithFormat:@"%d", comps.day] forState:UIControlStateNormal];
+        [self setTitle:[NSString stringWithFormat:@"%ld", (long)comps.day] forState:UIControlStateNormal];
     } else {
         [self setTitle:@"" forState:UIControlStateNormal];
     }

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -126,14 +126,10 @@
 @dynamic locale;
 
 - (id)init {
-    return [self initWithStartDay:startSunday];
+    return [self initWithFrame:CGRectMake(0, 0, 320, 320)];
 }
 
-- (id)initWithStartDay:(CKCalendarStartDay)firstDay {
-    return [self initWithStartDay:firstDay frame:CGRectMake(0, 0, 320, 320)];
-}
-
-- (void)_init:(CKCalendarStartDay)firstDay {
+- (void)_init {
     self.calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     [self.calendar setLocale:[NSLocale currentLocale]];
 
@@ -143,7 +139,6 @@
     [self.dateFormatter setTimeStyle:NSDateFormatterNoStyle];
     self.dateFormatter.dateFormat = @"LLLL yyyy";
 
-    self.calendarStartDay = firstDay;
     self.onlyShowCurrentMonth = YES;
     self.adaptHeightToNumberOfWeeksInMonth = YES;
 
@@ -222,22 +217,18 @@
     [self layoutSubviews]; // TODO: this is a hack to get the first month to show properly
 }
 
-- (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame {
+- (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        [self _init:firstDay];
+        [self _init];
     }
     return self;
-}
-
-- (id)initWithFrame:(CGRect)frame {
-    return [self initWithStartDay:startSunday frame:frame];
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        [self _init:startSunday];
+        [self _init];
     }
     return self;
 }
@@ -345,13 +336,6 @@
         [[self.dayOfWeekLabels objectAtIndex:i] setText:[day uppercaseString]];
         i++;
     }
-}
-
-- (void)setCalendarStartDay:(CKCalendarStartDay)calendarStartDay {
-    _calendarStartDay = calendarStartDay;
-    [self.calendar setFirstWeekday:self.calendarStartDay];
-    [self _updateDayOfWeekLabels];
-    [self setNeedsLayout];
 }
 
 - (void)setLocale:(NSLocale *)locale {


### PR DESCRIPTION
Hi Jay, I am not sure whether you want to pull these changes but I thought to offer them anyway. I have a need to keep the calender align to current locale settings. So I cut out the first day of the week option.

Thanks for your effort! I will see whether my app will make it and make a reference.
