### PR TITLE
Create stylings to make CKCalendar conform to flat design.

### DIFF
--- a/Examples/Calendar.xcodeproj/project.pbxproj
+++ b/Examples/Calendar.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		1D2391395A8710F3E85A8A /* left_arrow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1D2391395A8710F3E85A89 /* left_arrow@2x.png */; };
 		1D2391395A8710F3E85A8C /* right_arrow.png in Resources */ = {isa = PBXBuildFile; fileRef = 1D2391395A8710F3E85A8B /* right_arrow.png */; };
 		1D2391395A8710F3E85A8E /* right_arrow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1D2391395A8710F3E85A8D /* right_arrow@2x.png */; };
+		96D75AF818FF288500498AD7 /* HCTwoWeekCalendarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 96D75AF718FF288500498AD7 /* HCTwoWeekCalendarView.xib */; };
+		96D75AFB18FF31A900498AD7 /* HCPTwoWeekCalendarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 96D75AFA18FF31A900498AD7 /* HCPTwoWeekCalendarViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +44,9 @@
 		1D2391395A8710F3E85A89 /* left_arrow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "left_arrow@2x.png"; path = "../../Source/resources/left_arrow@2x.png"; sourceTree = "<group>"; };
 		1D2391395A8710F3E85A8B /* right_arrow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = right_arrow.png; path = ../../Source/resources/right_arrow.png; sourceTree = "<group>"; };
 		1D2391395A8710F3E85A8D /* right_arrow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "right_arrow@2x.png"; path = "../../Source/resources/right_arrow@2x.png"; sourceTree = "<group>"; };
+		96D75AF718FF288500498AD7 /* HCTwoWeekCalendarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HCTwoWeekCalendarView.xib; sourceTree = "<group>"; };
+		96D75AF918FF31A900498AD7 /* HCPTwoWeekCalendarViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HCPTwoWeekCalendarViewController.h; sourceTree = "<group>"; };
+		96D75AFA18FF31A900498AD7 /* HCPTwoWeekCalendarViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HCPTwoWeekCalendarViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +101,9 @@
 				1D2391395A8710F3E85A66 /* CKViewController.h */,
 				1D2391395A8710F3E85A64 /* CKAppDelegate.m */,
 				1D2391395A8710F3E85A63 /* CKAppDelegate.h */,
+				96D75AF918FF31A900498AD7 /* HCPTwoWeekCalendarViewController.h */,
+				96D75AFA18FF31A900498AD7 /* HCPTwoWeekCalendarViewController.m */,
+				96D75AF718FF288500498AD7 /* HCTwoWeekCalendarView.xib */,
 				1D2391395A8710F3E85A5B /* Supporting Files */,
 				1D2391395A8710F3E85A86 /* resources */,
 			);
@@ -149,6 +157,8 @@
 /* Begin PBXProject section */
 		001D2391395A8710F3E85A45 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 1D2391395A8710F3E85A46 /* Build configuration list for PBXProject "Calendar" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -175,6 +185,7 @@
 				1D2391395A8710F3E85A88 /* left_arrow.png in Resources */,
 				1D2391395A8710F3E85A8A /* left_arrow@2x.png in Resources */,
 				1D2391395A8710F3E85A8C /* right_arrow.png in Resources */,
+				96D75AF818FF288500498AD7 /* HCTwoWeekCalendarView.xib in Resources */,
 				1D2391395A8710F3E85A8E /* right_arrow@2x.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -190,6 +201,7 @@
 				1D2391395A8710F3E85A65 /* CKAppDelegate.m in Sources */,
 				1D2391395A8710F3E85A68 /* CKViewController.m in Sources */,
 				1D2391395A8710F3E85A85 /* CKCalendarView.m in Sources */,
+				96D75AFB18FF31A900498AD7 /* HCPTwoWeekCalendarViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -260,6 +272,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Calendar/Calendar-Prefix.pch";
 				INFOPLIST_FILE = "Calendar/Calendar-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -271,6 +284,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Calendar/Calendar-Prefix.pch";
 				INFOPLIST_FILE = "Calendar/Calendar-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -295,6 +309,7 @@
 				1D2391395A8710F3E85A4F /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Examples/Calendar/CKAppDelegate.m
+++ b/Examples/Calendar/CKAppDelegate.m
@@ -12,8 +12,10 @@
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
+    
     self.viewController = [[CKViewController alloc] init];
-    self.window.rootViewController = self.viewController;
+    UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:self.viewController];
+    self.window.rootViewController = navCtrl;
     [self.window makeKeyAndVisible];
     return YES;
 }

--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -80,8 +80,6 @@
     
     self.view.backgroundColor = [UIColor whiteColor];
     
-    // [calendar setDayOfWeekBottomColor:[UIColor greenColor] topColor:[UIColor redColor]];
-    
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(localeDidChange) name:NSCurrentLocaleDidChangeNotification object:nil];
 }
 

--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -1,6 +1,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import "CKViewController.h"
 #import "CKCalendarView.h"
+#import "HCPTwoWeekCalendarViewController.h"
 
 @interface CKViewController () <CKCalendarDelegate>
 
@@ -28,9 +29,28 @@
         [self addNonFlatDesignCalendar:CGRectMake(10, 44, 300, 320)];
         [self addFlatDesignCalendar:CGRectMake(10, 420, 300, 320)];
         
+        [self addButtonToGotoTwoWeekViewController:CGRectMake(10, 720, 200, 22)];
+        
         [self.view addSubview:self.scrollView];
     }
     return self;
+}
+
+- (void)addButtonToGotoTwoWeekViewController:(CGRect)rect
+{
+    UIButton *button = [[UIButton alloc] initWithFrame:rect];
+    
+    [button setTitle:@"Goto" forState:UIControlStateNormal];
+    button.backgroundColor = [UIColor redColor];
+    
+    [button addTarget:self action:@selector(gotoTwoWeekViewClicked:) forControlEvents:UIControlEventTouchUpInside];
+    [self.scrollView addSubview:button];
+}
+
+- (void)gotoTwoWeekViewClicked:(id)sender
+{
+    UIViewController *viewController = [[HCPTwoWeekCalendarViewController alloc] init];
+    [self.navigationController pushViewController:viewController animated:YES];
 }
 
 - (void)addNonFlatDesignCalendar:(CGRect)rect {

--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -90,7 +90,7 @@
     
     self.view.backgroundColor = [UIColor whiteColor];
     
-    [calendar setDayOfWeekBottomColor:[UIColor greenColor] topColor:[UIColor redColor]];
+    // [calendar setDayOfWeekBottomColor:[UIColor greenColor] topColor:[UIColor redColor]];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(localeDidChange) name:NSCurrentLocaleDidChangeNotification object:nil];
 }

--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -10,7 +10,7 @@
 @property(nonatomic, strong) UILabel *dateLabelNonFlat;
 @property(nonatomic, strong) NSDateFormatter *dateFormatter;
 @property(nonatomic, strong) NSDate *minimumDate;
-@property(nonatomic, strong) NSArray *disabledDates;
+@property(nonatomic, strong) NSDate *disabledDate;
 @property(nonatomic, strong) UIScrollView *scrollView;
 
 @end
@@ -42,11 +42,7 @@
     [self.dateFormatter setDateFormat:@"dd/MM/yyyy"];
     self.minimumDate = [self.dateFormatter dateFromString:@"20/09/2012"];
     
-    self.disabledDates = @[
-                           [self.dateFormatter dateFromString:@"05/01/2013"],
-                           [self.dateFormatter dateFromString:@"06/01/2013"],
-                           [self.dateFormatter dateFromString:@"07/01/2013"]
-                           ];
+    self.disabledDate = [self.dateFormatter dateFromString:@"05/01/2014"];
     
     calendar.onlyShowCurrentMonth = NO;
     calendar.adaptHeightToNumberOfWeeksInMonth = YES;
@@ -71,16 +67,10 @@
     [self.dateFormatter setDateFormat:@"dd/MM/yyyy"];
     self.minimumDate = [self.dateFormatter dateFromString:@"20/09/2012"];
     
-    self.disabledDates = @[
-                           [self.dateFormatter dateFromString:@"05/01/2013"],
-                           [self.dateFormatter dateFromString:@"06/01/2013"],
-                           [self.dateFormatter dateFromString:@"07/01/2013"]
-                           ];
+    self.disabledDate = [self.dateFormatter dateFromString:@"01/05/2014"],
     
     calendar.onlyShowCurrentMonth = NO;
     calendar.adaptHeightToNumberOfWeeksInMonth = YES;
-    // you can now set the out of month date item background color
-    // calendar.outOfMonthBackgroundColor = [UIColor redColor];
     
     calendar.frame = rect;
     [self.scrollView addSubview:calendar];
@@ -126,10 +116,8 @@
 }
 
 - (BOOL)dateIsDisabled:(NSDate *)date {
-    for (NSDate *disabledDate in self.disabledDates) {
-        if ([disabledDate isEqualToDate:date]) {
-            return YES;
-        }
+    if ([self.disabledDate isEqualToDate:date]) {
+        return YES;
     }
     return NO;
 }

--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -4,47 +4,91 @@
 
 @interface CKViewController () <CKCalendarDelegate>
 
-@property(nonatomic, weak) CKCalendarView *calendar;
-@property(nonatomic, strong) UILabel *dateLabel;
+@property(nonatomic, weak) CKCalendarView *nonFlatCalendar;
+@property(nonatomic, weak) CKCalendarView *flatCalendar;
+@property(nonatomic, strong) UILabel *dateLabelFlat;
+@property(nonatomic, strong) UILabel *dateLabelNonFlat;
 @property(nonatomic, strong) NSDateFormatter *dateFormatter;
 @property(nonatomic, strong) NSDate *minimumDate;
 @property(nonatomic, strong) NSArray *disabledDates;
+@property(nonatomic, strong) UIScrollView *scrollView;
 
 @end
 
 @implementation CKViewController
 
+
 - (id)init {
     self = [super init];
     if (self) {
-        CKCalendarView *calendar = [[CKCalendarView alloc] initWithStartDay:startMonday];
-        self.calendar = calendar;
-        calendar.delegate = self;
-
-        self.dateFormatter = [[NSDateFormatter alloc] init];
-        [self.dateFormatter setDateFormat:@"dd/MM/yyyy"];
-        self.minimumDate = [self.dateFormatter dateFromString:@"20/09/2012"];
-
-        self.disabledDates = @[
-                [self.dateFormatter dateFromString:@"05/01/2013"],
-                [self.dateFormatter dateFromString:@"06/01/2013"],
-                [self.dateFormatter dateFromString:@"07/01/2013"]
-        ];
-
-        calendar.onlyShowCurrentMonth = NO;
-        calendar.adaptHeightToNumberOfWeeksInMonth = YES;
-
-        calendar.frame = CGRectMake(10, 10, 300, 320);
-        [self.view addSubview:calendar];
-
-        self.dateLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, CGRectGetMaxY(calendar.frame) + 4, self.view.bounds.size.width, 24)];
-        [self.view addSubview:self.dateLabel];
-
-        self.view.backgroundColor = [UIColor whiteColor];
-
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(localeDidChange) name:NSCurrentLocaleDidChangeNotification object:nil];
+        self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.frame];
+        self.scrollView.scrollEnabled = YES;
+        self.scrollView.contentSize = CGSizeMake(320, 800);
+        
+        [self addNonFlatDesignCalendar:CGRectMake(10, 44, 300, 320)];
+        [self addFlatDesignCalendar:CGRectMake(10, 420, 300, 320)];
+        
+        [self.view addSubview:self.scrollView];
     }
     return self;
+}
+
+- (void)addNonFlatDesignCalendar:(CGRect)rect {
+    CKCalendarView *calendar = [[CKCalendarView alloc] initWithStartDay:startMonday];
+    self.nonFlatCalendar = calendar;
+    self.nonFlatCalendar.delegate = self;
+    
+    self.dateFormatter = [[NSDateFormatter alloc] init];
+    [self.dateFormatter setDateFormat:@"dd/MM/yyyy"];
+    self.minimumDate = [self.dateFormatter dateFromString:@"20/09/2012"];
+    
+    self.disabledDates = @[
+                           [self.dateFormatter dateFromString:@"05/01/2013"],
+                           [self.dateFormatter dateFromString:@"06/01/2013"],
+                           [self.dateFormatter dateFromString:@"07/01/2013"]
+                           ];
+    
+    calendar.onlyShowCurrentMonth = NO;
+    calendar.adaptHeightToNumberOfWeeksInMonth = YES;
+    
+    calendar.frame = rect;
+    [self.scrollView addSubview:calendar];
+    
+    self.dateLabelNonFlat = [[UILabel alloc] initWithFrame:CGRectMake(10, CGRectGetMaxY(calendar.frame), self.view.bounds.size.width, 24)];
+    [self.scrollView addSubview:self.dateLabelNonFlat];
+    
+    self.view.backgroundColor = [UIColor whiteColor];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(localeDidChange) name:NSCurrentLocaleDidChangeNotification object:nil];
+}
+
+- (void)addFlatDesignCalendar:(CGRect)rect {
+    CKCalendarView *calendar = [[CKCalendarView alloc] initWithStartDay:startMonday style:CKCalendarStyleFlat];
+    self.flatCalendar = calendar;
+    self.flatCalendar.delegate = self;
+    
+    self.dateFormatter = [[NSDateFormatter alloc] init];
+    [self.dateFormatter setDateFormat:@"dd/MM/yyyy"];
+    self.minimumDate = [self.dateFormatter dateFromString:@"20/09/2012"];
+    
+    self.disabledDates = @[
+                           [self.dateFormatter dateFromString:@"05/01/2013"],
+                           [self.dateFormatter dateFromString:@"06/01/2013"],
+                           [self.dateFormatter dateFromString:@"07/01/2013"]
+                           ];
+    
+    calendar.onlyShowCurrentMonth = NO;
+    calendar.adaptHeightToNumberOfWeeksInMonth = YES;
+    
+    calendar.frame = rect;
+    [self.scrollView addSubview:calendar];
+    
+    self.dateLabelFlat = [[UILabel alloc] initWithFrame:CGRectMake(10, CGRectGetMaxY(calendar.frame), self.view.bounds.size.width, 24)];
+    [self.scrollView addSubview:self.dateLabelFlat];
+    
+    self.view.backgroundColor = [UIColor whiteColor];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(localeDidChange) name:NSCurrentLocaleDidChangeNotification object:nil];
 }
 
 - (void)dealloc {
@@ -73,7 +117,8 @@
 }
 
 - (void)localeDidChange {
-    [self.calendar setLocale:[NSLocale currentLocale]];
+    [self.flatCalendar setLocale:[NSLocale currentLocale]];
+    [self.nonFlatCalendar setLocale:[NSLocale currentLocale]];
 }
 
 - (BOOL)dateIsDisabled:(NSDate *)date {
@@ -101,15 +146,20 @@
 }
 
 - (void)calendar:(CKCalendarView *)calendar didSelectDate:(NSDate *)date {
-    self.dateLabel.text = [self.dateFormatter stringFromDate:date];
+    if (calendar == self.flatCalendar) {
+        self.dateLabelFlat.text = [self.dateFormatter stringFromDate:date];
+    } else {
+        self.dateLabelNonFlat.text = [self.dateFormatter stringFromDate:date];
+    }
+    
 }
 
 - (BOOL)calendar:(CKCalendarView *)calendar willChangeToMonth:(NSDate *)date {
     if ([date laterDate:self.minimumDate] == date) {
-        self.calendar.backgroundColor = [UIColor blueColor];
+        calendar.backgroundColor = [UIColor blueColor];
         return YES;
     } else {
-        self.calendar.backgroundColor = [UIColor redColor];
+        calendar.backgroundColor = [UIColor redColor];
         return NO;
     }
 }

--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -88,6 +88,8 @@
     
     self.view.backgroundColor = [UIColor whiteColor];
     
+    [calendar setDayOfWeekBottomColor:[UIColor greenColor] topColor:[UIColor redColor]];
+    
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(localeDidChange) name:NSCurrentLocaleDidChangeNotification object:nil];
 }
 

--- a/Examples/Calendar/CKViewController.m
+++ b/Examples/Calendar/CKViewController.m
@@ -79,6 +79,8 @@
     
     calendar.onlyShowCurrentMonth = NO;
     calendar.adaptHeightToNumberOfWeeksInMonth = YES;
+    // you can now set the out of month date item background color
+    // calendar.outOfMonthBackgroundColor = [UIColor redColor];
     
     calendar.frame = rect;
     [self.scrollView addSubview:calendar];

--- a/Examples/Calendar/HCPTwoWeekCalendarViewController.h
+++ b/Examples/Calendar/HCPTwoWeekCalendarViewController.h
@@ -1,0 +1,13 @@
+//
+//  HCPTwoWeekCalendarViewController.h
+//  Calendar
+//
+//  Created by Adam Perry-Pelletier on 4/16/14.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface HCPTwoWeekCalendarViewController : UIViewController
+
+@end

--- a/Examples/Calendar/HCPTwoWeekCalendarViewController.m
+++ b/Examples/Calendar/HCPTwoWeekCalendarViewController.m
@@ -1,0 +1,72 @@
+//
+//  HCPTwoWeekCalendarViewController.m
+//  Calendar
+//
+//  Created by Adam Perry-Pelletier on 4/16/14.
+//
+//
+
+#import "HCPTwoWeekCalendarViewController.h"
+#import "CKCalendarView.h"
+
+@interface HCPTwoWeekCalendarViewController ()
+
+@property(nonatomic, strong) NSDateFormatter *dateFormatter;
+
+@end
+
+@implementation HCPTwoWeekCalendarViewController
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+    }
+    return self;
+}
+
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    self.view.backgroundColor = [UIColor whiteColor];
+    [self addTwoWeekCalendarView:CGRectMake(0,100,320,112)];
+}
+
+- (void)addTwoWeekCalendarView:(CGRect)rect {
+    NSArray *array = [[NSBundle mainBundle] loadNibNamed:@"HCTwoWeekCalendarView" owner:nil options:nil];
+    UIView *calendarView = [array lastObject];
+    calendarView.frame = CGRectMake(0, rect.origin.y, calendarView.frame.size.width, calendarView.frame.size.height);
+    UIScrollView *innerCalendarView = (UIScrollView *)[calendarView viewWithTag:1];
+    
+    CKCalendarView *calendar = [[CKCalendarView alloc] initWithStartDay:startMonday
+                                                                  style:CKCalendarStyleFlat
+                                                         suppressHeader:YES
+                                                      suppressDayLabels:YES];
+    
+    self.dateFormatter = [[NSDateFormatter alloc] init];
+    [self.dateFormatter setDateFormat:@"dd/MM/yyyy"];
+
+    calendar.onlyShowCurrentMonth = NO;
+    calendar.adaptHeightToNumberOfWeeksInMonth = YES;
+    
+    [innerCalendarView addSubview:calendar];
+    innerCalendarView.contentSize = calendar.frame.size;
+    
+    [self.view addSubview:calendarView];
+}
+
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
+{
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+@end

--- a/Examples/Calendar/HCTwoWeekCalendarView.xib
+++ b/Examples/Calendar/HCTwoWeekCalendarView.xib
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment defaultVersion="1792" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="t8R-6E-uty">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="112"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MON" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bbi-Wr-ffJ">
+                    <rect key="frame" x="0.0" y="0.0" width="46" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MON" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tkP-4M-3iX">
+                    <rect key="frame" x="46" y="0.0" width="45" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MON" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QoP-tE-dmj">
+                    <rect key="frame" x="91" y="0.0" width="46" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MON" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Uv-Qg-P0P">
+                    <rect key="frame" x="137" y="0.0" width="46" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MON" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GTn-QG-FrE">
+                    <rect key="frame" x="183" y="0.0" width="45" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MON" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mC9-y5-85g">
+                    <rect key="frame" x="228" y="0.0" width="46" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MON" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7bC-jc-JTq">
+                    <rect key="frame" x="274" y="0.0" width="46" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" tag="1" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="99z-1o-HFO">
+                    <rect key="frame" x="0.0" y="20" width="320" height="92"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                </scrollView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+        </view>
+    </objects>
+</document>

--- a/Source/CKCalendarView.h
+++ b/Source/CKCalendarView.h
@@ -40,8 +40,8 @@ typedef enum : NSInteger {
 
 - (id)initWithStartDay:(CKCalendarStartDay)firstDay;
 - (id)initWithStartDay:(CKCalendarStartDay)firstDay style:(CKCalendarStyle)style;
-- (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame;
 - (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame style:(CKCalendarStyle)style;
+- (id)initWithStartDay:(CKCalendarStartDay)firstDay style:(CKCalendarStyle)style suppressHeader:(BOOL)suppressHeader suppressDayLabels:(BOOL)supressDayLabels;
 
 @property (nonatomic) CKCalendarStartDay calendarStartDay;
 @property (nonatomic, strong) NSLocale *locale;

--- a/Source/CKCalendarView.h
+++ b/Source/CKCalendarView.h
@@ -59,6 +59,7 @@ typedef enum : NSInteger {
 @property (nonatomic, strong) UIFont *dateOfWeekFont;
 @property (nonatomic, strong) UIColor *dayOfWeekTextColor;
 @property (nonatomic, strong) UIFont *dateFont;
+@property (nonatomic, assign) CGFloat cornerRadius;
 
 - (void)setMonthButtonColor:(UIColor *)color;
 - (void)setInnerBorderColor:(UIColor *)color;

--- a/Source/CKCalendarView.h
+++ b/Source/CKCalendarView.h
@@ -59,6 +59,7 @@ typedef enum : NSInteger {
 @property (nonatomic, strong) UIFont *dateOfWeekFont;
 @property (nonatomic, strong) UIColor *dayOfWeekTextColor;
 @property (nonatomic, strong) UIFont *dateFont;
+@property (nonatomic, strong) UIColor *outOfMonthBackgroundColor;
 
 - (void)setMonthButtonColor:(UIColor *)color;
 - (void)setInnerBorderColor:(UIColor *)color;

--- a/Source/CKCalendarView.h
+++ b/Source/CKCalendarView.h
@@ -31,10 +31,17 @@ typedef enum {
     startMonday = 2,
 } CKCalendarStartDay;
 
+typedef enum : NSInteger {
+    CKCalendarStyleSkeuomorphic,
+    CKCalendarStyleFlat
+} CKCalendarStyle;
+
 @interface CKCalendarView : UIView
 
 - (id)initWithStartDay:(CKCalendarStartDay)firstDay;
+- (id)initWithStartDay:(CKCalendarStartDay)firstDay style:(CKCalendarStyle)style;
 - (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame;
+- (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame style:(CKCalendarStyle)style;
 
 @property (nonatomic) CKCalendarStartDay calendarStartDay;
 @property (nonatomic, strong) NSLocale *locale;

--- a/Source/CKCalendarView.h
+++ b/Source/CKCalendarView.h
@@ -59,7 +59,6 @@ typedef enum : NSInteger {
 @property (nonatomic, strong) UIFont *dateOfWeekFont;
 @property (nonatomic, strong) UIColor *dayOfWeekTextColor;
 @property (nonatomic, strong) UIFont *dateFont;
-@property (nonatomic, assign) CGFloat cornerRadius;
 
 - (void)setMonthButtonColor:(UIColor *)color;
 - (void)setInnerBorderColor:(UIColor *)color;

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -143,7 +143,7 @@
 }
 
 - (void)_init:(CKCalendarStartDay)firstDay style:(CKCalendarStyle)style{
-    
+    self.style = style;
     self.calendarMargin = [self calendarMarginForStyle:style];
     
     self.calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
@@ -268,7 +268,7 @@
     [super layoutSubviews];
 
     CGFloat containerWidth = [self containerWidthForStyle:self.style];
-    self.cellWidth = (floorf(containerWidth / 7.0)) - CELL_BORDER_WIDTH;
+    self.cellWidth = [self cellWidthForStyle:self.style];
 
     NSInteger numberOfWeeksToShow = 6;
     if (self.adaptHeightToNumberOfWeeksInMonth) {
@@ -370,6 +370,27 @@
     }
     
     return containerWidth;
+}
+
+- (CGFloat)cellWidthForStyle:(CKCalendarStyle)style
+{
+    CGFloat containerWidth = [self containerWidthForStyle:style];
+    
+    CGFloat cellWidth = 0;
+    
+    switch (style) {
+        case CKCalendarStyleSkeuomorphic:
+            cellWidth = (floorf(containerWidth / 7.0)) - CELL_BORDER_WIDTH;
+            break;
+        case CKCalendarStyleFlat:
+            cellWidth = (containerWidth / 7.0) - CELL_BORDER_WIDTH;
+            break;
+        default:
+            cellWidth = (floorf(containerWidth / 7.0)) - CELL_BORDER_WIDTH;
+            break;
+    }
+    
+    return cellWidth;
 }
 
 - (void)_updateDayOfWeekLabels {

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -111,7 +111,7 @@
 @property(nonatomic, strong) UIButton *prevButton;
 @property(nonatomic, strong) UIButton *nextButton;
 @property(nonatomic, strong) UIView *calendarContainer;
-@property(nonatomic, strong) GradientView *daysHeader;
+@property(nonatomic, strong) UIView *daysHeader;
 @property(nonatomic, strong) NSArray *dayOfWeekLabels;
 @property(nonatomic, strong) NSMutableArray *dateButtons;
 @property(nonatomic, strong) NSDateFormatter *dateFormatter;
@@ -201,7 +201,7 @@
     [self addSubview:calendarContainer];
     self.calendarContainer = calendarContainer;
 
-    GradientView *daysHeader = [[GradientView alloc] initWithFrame:CGRectZero];
+    UIView *daysHeader = [[UIView alloc] initWithFrame:CGRectZero];
     daysHeader.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
     [self.calendarContainer addSubview:daysHeader];
     self.daysHeader = daysHeader;
@@ -293,11 +293,7 @@
     self.calendarContainer.frame = CGRectMake(self.calendarMargin, CGRectGetMaxY(self.titleLabel.frame), containerWidth, containerHeight);
     self.daysHeader.frame = CGRectMake(0, 0, self.calendarContainer.frame.size.width, DAYS_HEADER_HEIGHT);
 
-    CGRect lastDayFrame = CGRectZero;
-    for (UILabel *dayLabel in self.dayOfWeekLabels) {
-        dayLabel.frame = CGRectMake(CGRectGetMaxX(lastDayFrame) + CELL_BORDER_WIDTH, lastDayFrame.origin.y, self.cellWidth, self.daysHeader.frame.size.height);
-        lastDayFrame = dayLabel.frame;
-    }
+    [self loadDaysLabelsIntoDaysHeaderView];
 
     for (DateButton *dateButton in self.dateButtons) {
         dateButton.date = nil;
@@ -353,6 +349,15 @@
     
     if ([self.delegate respondsToSelector:@selector(calendar:didLayoutInRect:)]) {
         [self.delegate calendar:self didLayoutInRect:self.frame];
+    }
+}
+
+- (void)loadDaysLabelsIntoDaysHeaderView
+{
+    CGRect lastDayFrame = CGRectZero;
+    for (UILabel *dayLabel in self.dayOfWeekLabels) {
+        dayLabel.frame = CGRectMake(CGRectGetMaxX(lastDayFrame) + CELL_BORDER_WIDTH, lastDayFrame.origin.y, self.cellWidth, self.daysHeader.frame.size.height);
+        lastDayFrame = dayLabel.frame;
     }
 }
 
@@ -611,7 +616,18 @@
 }
 
 - (void)setDayOfWeekBottomColor:(UIColor *)bottomColor topColor:(UIColor *)topColor {
-    [self.daysHeader setColors:[NSArray arrayWithObjects:topColor, bottomColor, nil]];
+    [self.daysHeader removeFromSuperview];
+    self.daysHeader = nil;
+
+    GradientView *gradientView = [[GradientView alloc] initWithFrame:CGRectZero];
+    gradientView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
+    
+    [gradientView setColors:[NSArray arrayWithObjects:topColor, bottomColor, nil]];
+    self.daysHeader = gradientView;
+
+    [self.calendarContainer addSubview:self.daysHeader];
+        self.daysHeader.frame = CGRectMake(0, 0, self.calendarContainer.frame.size.width, DAYS_HEADER_HEIGHT);
+    [self loadDaysLabelsIntoDaysHeaderView];
 }
 
 - (void)setDateFont:(UIFont *)font {

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -27,6 +27,7 @@
 #define DAYS_HEADER_HEIGHT 22
 #define DEFAULT_CELL_WIDTH 43
 #define CELL_BORDER_WIDTH 1
+#define SMALLER_INNER_RADIUS_FACTOR 2.0f;
 
 #define UIColorFromRGB(rgbValue) [UIColor colorWithRed:((float)((rgbValue & 0xFF0000) >> 16))/255.0 green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/255.0 alpha:1.0]
 
@@ -159,11 +160,11 @@
     self.onlyShowCurrentMonth = YES;
     self.adaptHeightToNumberOfWeeksInMonth = YES;
 
-    self.layer.cornerRadius = 6.0f;
+    self.layer.cornerRadius = self.cornerRadius;
 
     UIView *highlight = [[UIView alloc] initWithFrame:CGRectZero];
     highlight.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.2];
-    highlight.layer.cornerRadius = 6.0f;
+    highlight.layer.cornerRadius = self.cornerRadius;
     [self addSubview:highlight];
     self.highlight = highlight;
 
@@ -194,7 +195,7 @@
     calendarContainer.layer.borderWidth = 1.0f;
     calendarContainer.layer.borderColor = [UIColor blackColor].CGColor;
     calendarContainer.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
-    calendarContainer.layer.cornerRadius = 4.0f;
+    calendarContainer.layer.cornerRadius = self.cornerRadius - SMALLER_INNER_RADIUS_FACTOR;
     calendarContainer.clipsToBounds = YES;
     [self addSubview:calendarContainer];
     self.calendarContainer = calendarContainer;
@@ -243,6 +244,7 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
+        self.cornerRadius = [self cornerRadiusForStyle:style];
         [self _init:firstDay style:style];
     }
     return self;
@@ -351,6 +353,24 @@
     if ([self.delegate respondsToSelector:@selector(calendar:didLayoutInRect:)]) {
         [self.delegate calendar:self didLayoutInRect:self.frame];
     }
+}
+
+- (CGFloat)cornerRadiusForStyle:(CKCalendarStyle)style
+{
+    CGFloat cornerRadius = 0;
+    
+    switch (style) {
+        case CKCalendarStyleSkeuomorphic:
+            cornerRadius = 6.0f;
+            break;
+        case CKCalendarStyleFlat:
+            cornerRadius = 0.0f;
+            break;
+        default:
+            break;
+    }
+    
+    return cornerRadius;
 }
 
 - (CGFloat)containerWidthForStyle:(CKCalendarStyle)style

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -123,6 +123,7 @@
 
 @property (nonatomic, assign) CKCalendarStyle style;
 @property (nonatomic, assign) NSInteger calendarMargin;
+@property (nonatomic, assign) CGFloat cornerRadius;
 
 @end
 

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -366,6 +366,7 @@
     for (UILabel *dayLabel in self.dayOfWeekLabels) {
         dayLabel.frame = CGRectMake(CGRectGetMaxX(lastDayFrame) + CELL_BORDER_WIDTH, lastDayFrame.origin.y, self.cellWidth, self.daysHeader.frame.size.height);
         lastDayFrame = dayLabel.frame;
+        [self.calendarContainer bringSubviewToFront:dayLabel];
     }
 }
 
@@ -634,7 +635,8 @@
     self.daysHeader = gradientView;
 
     [self.calendarContainer addSubview:self.daysHeader];
-        self.daysHeader.frame = CGRectMake(0, 0, self.calendarContainer.frame.size.width, DAYS_HEADER_HEIGHT);
+    self.daysHeader.frame = CGRectMake(0, 0, self.calendarContainer.frame.size.width, DAYS_HEADER_HEIGHT);
+    
     [self loadDaysLabelsIntoDaysHeaderView];
 }
 

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -120,6 +120,7 @@
 @property (nonatomic, strong) NSCalendar *calendar;
 @property(nonatomic, assign) CGFloat cellWidth;
 
+@property (nonatomic, assign) CKCalendarStyle style;
 @property (nonatomic, assign) NSInteger calendarMargin;
 
 @end
@@ -266,7 +267,7 @@
 - (void)layoutSubviews {
     [super layoutSubviews];
 
-    CGFloat containerWidth = self.bounds.size.width - (self.calendarMargin * 2);
+    CGFloat containerWidth = [self containerWidthForStyle:self.style];
     self.cellWidth = (floorf(containerWidth / 7.0)) - CELL_BORDER_WIDTH;
 
     NSInteger numberOfWeeksToShow = 6;
@@ -350,6 +351,22 @@
     if ([self.delegate respondsToSelector:@selector(calendar:didLayoutInRect:)]) {
         [self.delegate calendar:self didLayoutInRect:self.frame];
     }
+}
+
+- (CGFloat)containerWidthForStyle:(CKCalendarStyle)style
+{
+    CGFloat containerWidth = 0;
+    
+    switch (style) {
+        case CKCalendarStyleSkeuomorphic:
+            containerWidth = self.bounds.size.width - (self.calendarMargin * 2);
+            break;
+        default:
+            containerWidth = self.bounds.size.width - (self.calendarMargin * 2);
+            break;
+    }
+    
+    return containerWidth;
 }
 
 - (void)_updateDayOfWeekLabels {

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -160,6 +160,7 @@
     self.calendarStartDay = firstDay;
     self.onlyShowCurrentMonth = YES;
     self.adaptHeightToNumberOfWeeksInMonth = YES;
+    self.outOfMonthBackgroundColor = UIColorFromRGB(0xE6E6E6);
 
     self.layer.cornerRadius = self.cornerRadius;
 
@@ -323,8 +324,9 @@
         if ([self _dateIsToday:dateButton.date]) {
             item.textColor = UIColorFromRGB(0xF2F2F2);
             item.backgroundColor = [UIColor lightGrayColor];
-        } else if (!self.onlyShowCurrentMonth && [self _compareByMonth:date toDate:self.monthShowing] != NSOrderedSame) {
+        } else if ([self _dayIsOutsideOfCurrentMonth:date]) {
             item.textColor = [UIColor lightGrayColor];
+            item.backgroundColor = self.outOfMonthBackgroundColor;
         }
 
         if (self.delegate && [self.delegate respondsToSelector:@selector(calendar:configureDateItem:forDate:)]) {
@@ -351,6 +353,12 @@
         [self.delegate calendar:self didLayoutInRect:self.frame];
     }
 }
+
+- (BOOL)_dayIsOutsideOfCurrentMonth:(NSDate *)date
+{
+    return !self.onlyShowCurrentMonth && [self _compareByMonth:date toDate:self.monthShowing] != NSOrderedSame;
+}
+
 
 - (void)loadDaysLabelsIntoDaysHeaderView
 {

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -21,7 +21,8 @@
 #import "CKCalendarView.h"
 
 #define BUTTON_MARGIN 4
-#define CALENDAR_MARGIN 5
+#define CALENDAR_MARGIN_SKEW 5
+#define CALENDAR_MARGIN_FLAT 0
 #define TOP_HEIGHT 44
 #define DAYS_HEADER_HEIGHT 22
 #define DEFAULT_CELL_WIDTH 43
@@ -119,6 +120,8 @@
 @property (nonatomic, strong) NSCalendar *calendar;
 @property(nonatomic, assign) CGFloat cellWidth;
 
+@property (nonatomic, assign) NSInteger calendarMargin;
+
 @end
 
 @implementation CKCalendarView
@@ -130,10 +133,18 @@
 }
 
 - (id)initWithStartDay:(CKCalendarStartDay)firstDay {
-    return [self initWithStartDay:firstDay frame:CGRectMake(0, 0, 320, 320)];
+    return [self initWithStartDay:firstDay frame:CGRectMake(0, 0, 320, 320)] ;
 }
 
-- (void)_init:(CKCalendarStartDay)firstDay {
+- (id)initWithStartDay:(CKCalendarStartDay)firstDay style:(CKCalendarStyle)style
+{
+    return [self initWithStartDay:firstDay frame:CGRectMake(0, 0, 320, 320) style:style];
+}
+
+- (void)_init:(CKCalendarStartDay)firstDay style:(CKCalendarStyle)style{
+    
+    self.calendarMargin = [self calendarMarginForStyle:style];
+    
     self.calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     [self.calendar setLocale:[NSLocale currentLocale]];
 
@@ -222,22 +233,32 @@
     [self layoutSubviews]; // TODO: this is a hack to get the first month to show properly
 }
 
-- (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame {
+- (NSInteger)calendarMarginForStyle:(CKCalendarStyle)style
+{
+    return style == CKCalendarStyleFlat ? CALENDAR_MARGIN_FLAT : CALENDAR_MARGIN_SKEW;
+}
+
+- (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame style:(CKCalendarStyle)style
+{
     self = [super initWithFrame:frame];
     if (self) {
-        [self _init:firstDay];
+        [self _init:firstDay style:style];
     }
     return self;
 }
 
+- (id)initWithStartDay:(CKCalendarStartDay)firstDay frame:(CGRect)frame {
+    return [self initWithStartDay:firstDay frame:frame style:CKCalendarStyleSkeuomorphic];
+}
+
 - (id)initWithFrame:(CGRect)frame {
-    return [self initWithStartDay:startSunday frame:frame];
+    return [self initWithStartDay:startSunday frame:frame style:CKCalendarStyleSkeuomorphic];
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        [self _init:startSunday];
+        [self _init:startSunday style:CKCalendarStyleSkeuomorphic];
     }
     return self;
 }
@@ -245,7 +266,7 @@
 - (void)layoutSubviews {
     [super layoutSubviews];
 
-    CGFloat containerWidth = self.bounds.size.width - (CALENDAR_MARGIN * 2);
+    CGFloat containerWidth = self.bounds.size.width - (self.calendarMargin * 2);
     self.cellWidth = (floorf(containerWidth / 7.0)) - CELL_BORDER_WIDTH;
 
     NSInteger numberOfWeeksToShow = 6;
@@ -255,7 +276,7 @@
     CGFloat containerHeight = (numberOfWeeksToShow * (self.cellWidth + CELL_BORDER_WIDTH) + DAYS_HEADER_HEIGHT);
 
     CGRect newFrame = self.frame;
-    newFrame.size.height = containerHeight + CALENDAR_MARGIN + TOP_HEIGHT;
+    newFrame.size.height = containerHeight + self.calendarMargin + TOP_HEIGHT;
     self.frame = newFrame;
 
     self.highlight.frame = CGRectMake(1, 1, self.bounds.size.width - 2, 1);
@@ -265,7 +286,7 @@
     self.prevButton.frame = CGRectMake(BUTTON_MARGIN, BUTTON_MARGIN, 48, 38);
     self.nextButton.frame = CGRectMake(self.bounds.size.width - 48 - BUTTON_MARGIN, BUTTON_MARGIN, 48, 38);
 
-    self.calendarContainer.frame = CGRectMake(CALENDAR_MARGIN, CGRectGetMaxY(self.titleLabel.frame), containerWidth, containerHeight);
+    self.calendarContainer.frame = CGRectMake(self.calendarMargin, CGRectGetMaxY(self.titleLabel.frame), containerWidth, containerHeight);
     self.daysHeader.frame = CGRectMake(0, 0, self.calendarContainer.frame.size.width, DAYS_HEADER_HEIGHT);
 
     CGRect lastDayFrame = CGRectZero;

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -232,7 +232,7 @@
 
     // initialize the thing
     self.monthShowing = [NSDate date];
-    [self _setDefaultStyle];
+    [self _setDefaultStyle:style];
     
     [self layoutSubviews]; // TODO: this is a hack to get the first month to show properly
 }
@@ -512,7 +512,7 @@
     [self setNeedsLayout];
 }
 
-- (void)_setDefaultStyle {
+- (void)_setDefaultStyle:(CKCalendarStyle)style {
     self.backgroundColor = UIColorFromRGB(0x393B40);
 
     [self setTitleColor:[UIColor whiteColor]];
@@ -520,7 +520,10 @@
 
     [self setDayOfWeekFont:[UIFont boldSystemFontOfSize:12.0]];
     [self setDayOfWeekTextColor:UIColorFromRGB(0x999999)];
-    [self setDayOfWeekBottomColor:UIColorFromRGB(0xCCCFD5) topColor:[UIColor whiteColor]];
+
+    if (style == CKCalendarStyleSkeuomorphic) {
+        [self setDayOfWeekBottomColor:UIColorFromRGB(0xCCCFD5) topColor:[UIColor whiteColor]];
+    }
 
     [self setDateFont:[UIFont boldSystemFontOfSize:16.0f]];
     [self setDateBorderColor:UIColorFromRGB(0xDAE1E6)];

--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -361,6 +361,9 @@
         case CKCalendarStyleSkeuomorphic:
             containerWidth = self.bounds.size.width - (self.calendarMargin * 2);
             break;
+        case CKCalendarStyleFlat:
+            containerWidth = self.bounds.size.width;
+            break;
         default:
             containerWidth = self.bounds.size.width - (self.calendarMargin * 2);
             break;


### PR DESCRIPTION
The series of commits passes in a flag and some customizations that make the CKCalendar conform to flat design of iOS 7.  When in flat mode the corner radius is removed.  The gradient view for the date labels is removed.
