### PR TITLE
Fixed setWeek: deprecation with setWeekOfMonth:

### DIFF
--- a/Source/CKCalendarView.m
+++ b/Source/CKCalendarView.m
@@ -289,7 +289,7 @@
     NSDate *endDate = [self _firstDayOfNextMonthContainingDate:self.monthShowing];
     if (!self.onlyShowCurrentMonth) {
         NSDateComponents *comps = [[NSDateComponents alloc] init];
-        [comps setWeek:numberOfWeeksToShow];
+        [comps setWeekOfMonth:numberOfWeeksToShow];
         endDate = [self.calendar dateByAddingComponents:comps toDate:date options:0];
     }
 


### PR DESCRIPTION
setWeek: has been deprecated in iOS 7 and we are supposed to use setWeekOfMonth: (or setWeekOfYear:) which are compatible from iOS 5.
